### PR TITLE
add mouseover 'home' on the logo

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon"style="padding: 5px 15px 0px 15px">
   <%= link_to root_path, class: "navbar-brand" do %>
-    <i class="fab fa-pagelines fa-lg logo"></i>
+    <i class="fab fa-pagelines fa-lg logo" title="Home"></i>
   <% end %>
 
   <!-- /app/assets/images/terrace_logo.png -->


### PR DESCRIPTION
I added a mouseover over the logo in the navbar so that we can read 'Home' when the mouse is over